### PR TITLE
fix: parse_curl mangles tokens from shlex.split with backslash-newline continuation

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -1438,6 +1438,13 @@ def parse_curl(curl: str) -> dict:
         tokens = shlex.split(curl)
     except ValueError:
         tokens = curl.replace("\\\n", " ").split()
+    # When cURL uses \\\n (backslash-newline) continuation (e.g. Chrome
+    # DevTools "Copy as cURL" on macOS), shlex.split preserves '\n' as
+    # the first character of the following token, producing "\n-H" or
+    # "\n--data-raw".  Strip only leading '\n' — not all whitespace —
+    # so intentional whitespace in values is preserved.
+    tokens = [t.lstrip('\n') for t in tokens]
+    tokens = [t for t in tokens if t]
     out = {"url": "", "headers": {}, "body": ""}
     i = 0
     while i < len(tokens):


### PR DESCRIPTION
## Problem

When users copy cURL from browser DevTools (Copy as cURL), the multi-line backslash-newline continuations cause `shlex.split()` to produce tokens like `"\n-H"` instead of the expected `"-H"`. 

These malformed tokens fail both:
- `t in ("-H", "--header")` — token is `\n-H`, not `-H`
- `t.startswith("-")` — token starts with `\n`, not `-`

As a result, all headers are silently dropped, and the user sees: `未从 cURL 提取到 Token，请确认 Authorization header`.

## Root Cause

`shlex.split()` preserves the newline from `\\\n` continuation as part of the following token. For example, `-H 'Authorization: Bearer xxx'` becomes token `"\n-H"` and its value `Authorization: Bearer xxx`.

## Fix

Strip leading whitespace from every token and filter out empty tokens before the main parsing loop (3 lines added).

## Verification

Tested with a real cURL command copied from Chrome DevTools (20 headers, including Cookie with special chars, x-ds-pow-response, etc.):

Before: 0 headers extracted, token missing
After: 20 headers extracted, token and session_id correctly parsed